### PR TITLE
Convert Windows path separator to *nix

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ Elixir.extend('templates', function (src, output) {
                 root: 'exports',
                 noRedeclare: true, // Avoid duplicate declarations
                 processName: function (filePath) {
-                    return declare.processNameByPath(filePath.substring(filePath.lastIndexOf('/')+1));
+                    return declare.processNameByPath(filePath.substring(filePath.replace(/\\/g, '/').lastIndexOf('/')+1));
                 }
             }))
 


### PR DESCRIPTION
This patch allows Windows users to generate the same output as *nix systems users.
